### PR TITLE
Fix bracket matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,14 +37,7 @@ const interp = new Basic({
 interp
   .run(
     `
-10 PAUSE 0.1
-20 ARRAY I
-92 LET I[0] =5
-95 LET I[1] = 10
-98 PRINT I
-100 FOR I = 1 TO 9 STEP 2
-110 PRINT I
-120 NEXT I
+10 PRINT ("1)\" + "4")
 
 `,
   )

--- a/parser.test.js
+++ b/parser.test.js
@@ -294,6 +294,18 @@ const tErr = (line, errorString) => {
 const lerr = (errorString) => `Parse error on line 1: ${errorString}`
 
 describe('Parse errors', () => {
+  describe('Bracket matching', () => {
+    // extra closing
+    tErr('1 PRINT (1+1', lerr('You have unmatched brackets. Make sure your brackets are balanced'));
+    // umatched
+    tErr('1 PRINT 1+1)', lerr('Found extra closing bracket )'));
+    // out of order
+    tErr('1 PRINT A[(1+1])', lerr('Unexpected bracket ]. There is an unmatched ( so it is expected to see ) before ]'));
+    test('1 Ignores brackets in strings', () => {
+      expect(() => Parser.parseLine('1 PRINT ("a" + ")")')).not.toThrow()
+    });
+  });
+
   describe('lineno', () => {
     tErr('PRINT "HI"', 'Parse error on line -1: Every line must start with a line number');
   });
@@ -315,8 +327,8 @@ describe('Parse errors', () => {
   });
 
   describe('INPUT', () => {
-    tErr('1 INPUT', lerr('Expected prompt value after INPUT'));
-    tErr('1 INPUT "prompt text"', lerr('Expected ; after INPUT'));
+    tErr('1 INPUT', lerr('Expected prompt text after INPUT'));
+    tErr('1 INPUT "prompt text"', lerr('Expected a ";" after "prompt text" but got a end of line'));
     tErr('1 INPUT "got mod";', lerr('Expected a variable after ";" but got a end of line instead 😕'));
   });
 

--- a/tokenizer.js
+++ b/tokenizer.js
@@ -117,21 +117,6 @@ class Tokenizer {
     return this.tokens[this.index++];
   }
 
-  nextExpr() {
-    this.assertTokenized();
-
-    const expr = [];
-    while (this.index !== this.tokens.length) {
-      if (!Tokenizer.expressionTypes.includes(this.peek().type)) {
-        break;
-      }
-
-      expr.push(this.next());
-    }
-
-    return expr;
-  }
-
   tokenize() {
     const linem = this.stmnt.match(LINE);
 


### PR DESCRIPTION
Added a preparse step to make sure brackets are properly matched! The function just checks if bracket tokens are balanced!

The reason this is a pre-parse step and not part of `expectExpr` is because we need global state on the parser for us to be able to check if the line is balanced when we have nested expressions.