### PR TITLE
Fix for off-by-one error in FOR NEXT loops.

### DIFF
--- a/basic.js
+++ b/basic.js
@@ -287,9 +287,9 @@ class Basic {
     this.set(loop.variable, loop.value);
 
     if (loop.increment > 0) {
-      if (loop.value >= loop.max) return;
+      if (loop.value > loop.max) return;
     } else if (loop.increment < 0) {
-      if (loop.value <= loop.max) return;
+      if (loop.value < loop.max) return;
     }
 
     this.goto(loop.lineno);

--- a/basic.test.js
+++ b/basic.test.js
@@ -413,3 +413,39 @@ test('sound', async () => {
   expect(sound.sound.mock.calls[0]).toEqual([9, 1]);
   expect(sound.sound.mock.calls[1]).toEqual([8, 2]);  
 });
+
+test('for next loop', async () => {
+  const { interp, output } = createBasic();
+  let out = [];
+  output.write = str => {
+    if (str !== '\n') {
+      out.push(str);
+    }
+  };
+
+  await interp.run(`
+  for i = 1 to 3
+  print i
+  next i
+  `);
+  
+  expect(out).toEqual(['1', '2', '3']);
+});
+
+test('for next step loop', async () => {
+  const { interp, output } = createBasic();
+  let out = [];
+  output.write = str => {
+    if (str !== '\n') {
+      out.push(str);
+    }
+  };
+
+  await interp.run(`
+  for i = 3 to 1 step -1
+  print i
+  next i
+  `);
+  
+  expect(out).toEqual(['3', '2', '1']);
+});


### PR DESCRIPTION
Loops such as:
10 FOR I = 1 TO 3
20 PRINT I
30 NEXT I

Would only output:
1
2

leaving out the last iteration "3".

This changes fixes this bug for both positive and negative STEP values
and adds 2 unit tests.